### PR TITLE
Relese 1.7

### DIFF
--- a/vehicle/OVMS.X/vehicle_mitsubishi.c
+++ b/vehicle/OVMS.X/vehicle_mitsubishi.c
@@ -361,6 +361,7 @@ BOOL vehicle_mitsubishi_poll0(void)
           mi_quick_charge = 1;
           mi_stale_charge = 30; // Reset stale charging indicator
           }
+        }
 
       else
         {


### PR DESCRIPTION
- Added charge stale timer to prevent hanging in charging mode.
- Added car_SOCalertlimit = 10 to set a system alert when SOC < 10
- Added Motor and PEM temperature reading (thanks to Matt Beard)
- Added calculation of estimated range during QC (thanks to Matt Beard)
- Added detection of quick charging
- Fixed view stale temps in app
