### PR TITLE
- add params to vehicle_minutestocharge

### DIFF
--- a/vehicle/OVMS.X/net_msg.h
+++ b/vehicle/OVMS.X/net_msg.h
@@ -92,6 +92,7 @@ void net_msg_forward_sms(char* caller, char* SMS);
 void net_msg_reply_ussd(char *buf, unsigned char buflen);
 
 char *net_prep_stat(char *s);
+char *net_prep_ctp(char *s, char *arguments);
 void net_msg_alert(void);
 void net_msg_valettrunk(void);
 void net_msg_alarm(void);

--- a/vehicle/OVMS.X/net_sms.c
+++ b/vehicle/OVMS.X/net_sms.c
@@ -126,6 +126,22 @@ BOOL net_sms_stat(char* number)
   return TRUE;
   }
 
+BOOL net_sms_ctp(char* number, char *arguments)
+  {
+  char *p;
+
+  if (sys_features[FEATURE_CARBITS]&FEATURE_CB_SOUT_SMS) return FALSE;
+
+  delay100(2);
+  net_send_sms_start(number);
+  
+  net_prep_ctp(net_scratchpad, arguments);
+  cr2lf(net_scratchpad);
+  net_puts_ram(net_scratchpad);
+
+  return TRUE;
+  }
+
 void net_sms_alarm(char* number)
   {
   char *p;
@@ -845,6 +861,11 @@ BOOL net_sms_handle_reset(char *caller, char *command, char *arguments)
   return FALSE;
   }
 
+BOOL net_sms_handle_ctp(char *caller, char *command, char *arguments)
+  {
+  return net_sms_ctp(caller, arguments);
+  }
+
 BOOL net_sms_handle_temps(char *caller, char *command, char *arguments)
   {
   char *s;
@@ -913,6 +934,7 @@ rom char sms_cmdtable[][NET_SMS_CMDWIDTH] =
     "2COOLDOWN",
     "3VERSION",
     "3RESET",
+    "3CTP",
     "3TEMPS",
 #ifdef OVMS_ACCMODULE
     "2ACC ",
@@ -955,6 +977,7 @@ rom BOOL (*sms_hfntable[])(char *caller, char *command, char *arguments) =
   &net_sms_handle_cooldown,
   &net_sms_handle_version,
   &net_sms_handle_reset,
+  &net_sms_handle_ctp,
   &net_sms_handle_temps,
 #ifdef OVMS_ACCMODULE
   &acc_handle_sms,

--- a/vehicle/OVMS.X/utils.c
+++ b/vehicle/OVMS.X/utils.c
@@ -131,16 +131,22 @@ unsigned char string_to_mode(char *mode)
 int timestring_to_mins(char* arg)
   {
   // Take a time string of the format HH:MM (24 hour) and return as number of minutes.
+  int min = 0;
+  int hour = 0;
   int sign = 1;
+  int *pval = &hour;
+  char ch;
 
-  if (*arg == 0) return 0;
-  if (*arg == '-') { sign = -1; arg++; }
-
-  return sign *
-         (((int)(arg[0] - '0')*600) +
-          ((int)(arg[1] - '0')*60) +
-          ((int)(arg[3] - '0')*10) +
-           (int)(arg[4] - '0'));
+  while ((ch = *arg++) != 0)
+    {
+    if (ch == '-')
+      sign = -sign;
+    else if (ch == ':')
+      pval = &min;
+    else
+      *pval = *pval*10 + ch - '0';
+    }
+  return sign*(hour*60 + min);
   }
 
 // convert miles to kilometers by multiplying by ~1.609344

--- a/vehicle/OVMS.X/vehicle.c
+++ b/vehicle/OVMS.X/vehicle.c
@@ -56,7 +56,7 @@ rom BOOL (*vehicle_fn_idlepoll)(void) = NULL;
 rom BOOL (*vehicle_fn_commandhandler)(BOOL msgmode, int code, char* msg);
 rom BOOL (*vehicle_fn_smshandler)(BOOL premsg, char *caller, char *command, char *arguments);
 rom BOOL (*vehicle_fn_smsextensions)(char *caller, char *command, char *arguments);
-rom int  (*vehicle_fn_minutestocharge)(unsigned char chgmod, int wAvail, int ixEnd, int pctEnd);
+rom int  (*vehicle_fn_minutestocharge)(unsigned char chgmod, int wAvail, int imStart, int imTarget, int pctTarget, int cac100, signed char degAmbient, int *pimExpect);
 
 ////////////////////////////////////////////////////////////////////////
 // vehicle_initialise()

--- a/vehicle/OVMS.X/vehicle.h
+++ b/vehicle/OVMS.X/vehicle.h
@@ -75,7 +75,7 @@ extern rom BOOL (*vehicle_fn_idlepoll)(void);
 extern rom BOOL (*vehicle_fn_commandhandler)(BOOL msgmode, int code, char* msg);
 extern rom BOOL (*vehicle_fn_smshandler)(BOOL premsg, char *caller, char *command, char *arguments);
 extern rom BOOL (*vehicle_fn_smsextensions)(char *caller, char *command, char *arguments);
-extern rom int  (*vehicle_fn_minutestocharge)(unsigned char chgmod, int wAvail, int ixEnd, int pctEnd);
+extern rom int  (*vehicle_fn_minutestocharge)(unsigned char chgmod, int wAvail, int imStart, int imTarget, int pctTarget, int cac100, signed char degAmbient, int *pimExpect);
 
 void vehicle_initialise(void);
 


### PR DESCRIPTION
- add params to vehicle_minutestocharge
- add #define for charge voltage assumed by ACC
- add CTP SMS command
- add timestamp to STAT SMS command
- generalize timestring_to_mins
- TR: CTP uses CAC100 for better resolution
- TR: move MinutesToChargeCAC code into vehicle_teslaroadster_minutestocharge
- TR: separate taper profiles for each charge mode
