### PR TITLE
Ubuntu crypt xs perl clients

### DIFF
--- a/client/README
+++ b/client/README
@@ -23,6 +23,9 @@ Install modules using cpanminus:
   cpanm Config::IniFiles Digest::MD5 Digest::HMAC Crypt::RC4 MIME::Base64 \
     IO::Socket::INET IO::Socket::Timeout Device::SerialPort
 
+Install modules using apt-get:
+  apt-get install libdigest-hmac-perl libcrypt-rc4-perl \
+    libconfig-inifiles-perl libdevice-serialport-perl
 
 The clients
 ===========

--- a/client/README
+++ b/client/README
@@ -10,7 +10,7 @@ The following perl modules from CPAN are used by the clients:
   Config::IniFiles
   Digest::MD5
   Digest::HMAC
-  Crypt::RC4::XS
+  Crypt::RC4
   MIME::Base64
   IO::Socket::INET
   IO::Socket::Timeout
@@ -20,7 +20,7 @@ The following perl modules from CPAN are used by the clients:
   Win32::SerialPort    (Windows)
 
 Install modules using cpanminus:
-  cpanm Config::IniFiles Digest::MD5 Digest::HMAC Crypt::RC4::XS MIME::Base64 \
+  cpanm Config::IniFiles Digest::MD5 Digest::HMAC Crypt::RC4 MIME::Base64 \
     IO::Socket::INET IO::Socket::Timeout Device::SerialPort
 
 

--- a/client/client_app.pl
+++ b/client/client_app.pl
@@ -2,7 +2,7 @@
 
 use Digest::MD5;
 use Digest::HMAC;
-use Crypt::RC4::XS;
+use Crypt::RC4;
 use MIME::Base64;
 use IO::Socket::INET;
 use Config::IniFiles;
@@ -71,9 +71,9 @@ $client_hmac->add($client_token);
 my $client_key = $client_hmac->digest;
 print STDERR "  Client version of shared key is: ",encode_base64($client_key,''),"\n";
 
-my $txcipher = Crypt::RC4::XS->new($client_key);
+my $txcipher = Crypt::RC4->new($client_key);
 $txcipher->RC4(chr(0) x 1024); # Prime the cipher
-my $rxcipher = Crypt::RC4::XS->new($client_key);
+my $rxcipher = Crypt::RC4->new($client_key);
 $rxcipher->RC4(chr(0) x 1024); # Prime the cipher
 
 my $encrypted = encode_base64($txcipher->RC4("MP-0 A"),'');
@@ -100,7 +100,7 @@ while(<$sock>)
   elsif ($decoded =~ /^MP-0 EM(.)(.*)/)
     {
     my ($code,$data) = ($1,$2);
-    my $pmcipher = Crypt::RC4::XS->new($pdigest);
+    my $pmcipher = Crypt::RC4->new($pdigest);
     $pmcipher->RC4(chr(0) x 1024); # Prime the cipher
     $decoded = $pmcipher->RC4(decode_base64($data));
     print STDERR "    Paranoid message $code $decoded\n";

--- a/client/cmd.pl
+++ b/client/cmd.pl
@@ -2,7 +2,7 @@
 
 use Digest::MD5;
 use Digest::HMAC;
-use Crypt::RC4::XS;
+use Crypt::RC4;
 use MIME::Base64;
 use IO::Socket::INET;
 use IO::Socket::Timeout;
@@ -81,9 +81,9 @@ $client_hmac->add($server_token);
 $client_hmac->add($client_token);
 my $client_key = $client_hmac->digest;
 
-my $txcipher = Crypt::RC4::XS->new($client_key);
+my $txcipher = Crypt::RC4->new($client_key);
 $txcipher->RC4(chr(0) x 1024); # Prime the cipher
-my $rxcipher = Crypt::RC4::XS->new($client_key);
+my $rxcipher = Crypt::RC4->new($client_key);
 $rxcipher->RC4(chr(0) x 1024); # Prime the cipher
 
 
@@ -135,7 +135,7 @@ while(1)
 	elsif ($decoded =~ /^MP-0 EM(.)(.*)/)
 	{
 		my ($code,$data) = ($1,$2);
-		my $pmcipher = Crypt::RC4::XS->new($pdigest);
+		my $pmcipher = Crypt::RC4->new($pdigest);
 		$pmcipher->RC4(chr(0) x 1024); # Prime the cipher
 		$decoded = $pmcipher->RC4(decode_base64($data));
 		# reformat as std msg:

--- a/client/notify.pl
+++ b/client/notify.pl
@@ -2,7 +2,7 @@
 
 use Digest::MD5;
 use Digest::HMAC;
-use Crypt::RC4::XS;
+use Crypt::RC4;
 use MIME::Base64;
 use IO::Socket::INET;
 use Config::IniFiles;
@@ -69,9 +69,9 @@ $client_hmac->add($server_token);
 $client_hmac->add($client_token);
 my $client_key = $client_hmac->digest;
 
-my $txcipher = Crypt::RC4::XS->new($client_key);
+my $txcipher = Crypt::RC4->new($client_key);
 $txcipher->RC4(chr(0) x 1024); # Prime the cipher
-my $rxcipher = Crypt::RC4::XS->new($client_key);
+my $rxcipher = Crypt::RC4->new($client_key);
 $rxcipher->RC4(chr(0) x 1024); # Prime the cipher
 
 

--- a/client/status.pl
+++ b/client/status.pl
@@ -2,7 +2,7 @@
 
 use Digest::MD5;
 use Digest::HMAC;
-use Crypt::RC4::XS;
+use Crypt::RC4;
 use MIME::Base64;
 use IO::Socket::INET;
 use Config::IniFiles;
@@ -69,9 +69,9 @@ $client_hmac->add($server_token);
 $client_hmac->add($client_token);
 my $client_key = $client_hmac->digest;
 
-my $txcipher = Crypt::RC4::XS->new($client_key);
+my $txcipher = Crypt::RC4->new($client_key);
 $txcipher->RC4(chr(0) x 1024); # Prime the cipher
-my $rxcipher = Crypt::RC4::XS->new($client_key);
+my $rxcipher = Crypt::RC4->new($client_key);
 $rxcipher->RC4(chr(0) x 1024); # Prime the cipher
 
 
@@ -113,7 +113,7 @@ while(1)
 	elsif ($decoded =~ /^MP-0 EM(.)(.*)/)
 	{
 		my ($code,$data) = ($1,$2);
-		my $pmcipher = Crypt::RC4::XS->new($pdigest);
+		my $pmcipher = Crypt::RC4->new($pdigest);
 		$pmcipher->RC4(chr(0) x 1024); # Prime the cipher
 		$decoded = $pmcipher->RC4(decode_base64($data));
 		# reformat as std msg:

--- a/client/subscribe.pl
+++ b/client/subscribe.pl
@@ -2,7 +2,7 @@
 
 use Digest::MD5;
 use Digest::HMAC;
-use Crypt::RC4::XS;
+use Crypt::RC4;
 use MIME::Base64;
 use IO::Socket::INET;
 use Config::IniFiles;
@@ -71,9 +71,9 @@ $client_hmac->add($server_token);
 $client_hmac->add($client_token);
 my $client_key = $client_hmac->digest;
 
-my $txcipher = Crypt::RC4::XS->new($client_key);
+my $txcipher = Crypt::RC4->new($client_key);
 $txcipher->RC4(chr(0) x 1024); # Prime the cipher
-my $rxcipher = Crypt::RC4::XS->new($client_key);
+my $rxcipher = Crypt::RC4->new($client_key);
 $rxcipher->RC4(chr(0) x 1024); # Prime the cipher
 
 


### PR DESCRIPTION
change perl clients to use CRYPT::RC4 instead of CRYPT::RC4::XS for easier ubuntu compatibility