### PR TITLE
Deterministic portc + fix led_set()

### DIFF
--- a/vehicle/OVMS.X/inputs.c
+++ b/vehicle/OVMS.X/inputs.c
@@ -48,6 +48,10 @@ void inputs_initialise(void)
    //   Automatic Acquisition Time = 20 TAD = 32 us
    ADCON2=0b10111010;
 #endif // #ifdef OVMS_HW_??
+  // set PORTC outputs we manage low so they're in a consistent state on startup
+  PORTC &= 0b11110000;
+  // switch PORTC outputs we manage to output mode
+  TRISC &= 0b11110000;
   }
 
 unsigned char inputs_gsmgprs(void)

--- a/vehicle/OVMS.X/led.c
+++ b/vehicle/OVMS.X/led.c
@@ -62,6 +62,7 @@ void led_start(void)
 void led_initialise(void)
   {
   PORTC &= 0b11001111; // Turn off both LEDs
+  TRISC &= 0b11001111; // Set both LEDs to outputs
 
   led_carticker = 0;
 

--- a/vehicle/OVMS.X/led.c
+++ b/vehicle/OVMS.X/led.c
@@ -46,7 +46,7 @@ void led_set(unsigned char led, signed char digit)
   if (digit == OVMS_LED_ON)
     {
     // Turn ON the LED, immediately
-    PORTC |= (1<<(OVMS_LED_O+digit));
+    PORTC |= (1 << (OVMS_LED_O + led));
     led_stat[led] = 0;
     }
   // N.B. We don't otherwise alter it for this run, as that would confuse the user

--- a/vehicle/OVMS.X/net.c
+++ b/vehicle/OVMS.X/net.c
@@ -1890,8 +1890,6 @@ void net_ticker10th(void)
 //
 void net_initialise(void)
   {
-  // I/O configuration PORT C
-  TRISC = 0x80; // Port C RC0-6 output, RC7 input
   UARTIntInit();
 
   net_reg = 0;


### PR DESCRIPTION
PORTC state is undefined at power on and retains state across reset, so we can't be sure what state it will be in at startup. This is an issue if you want to wake the car up using a PORTC output because the car may wake up during boot when you don't want it to (especially a problem if the OVMS is in a boot loop for some other reason).

Further there is a bug in led_set() which causes RC3 to be set high during startup.

This pull request 
* separates management of each PORTC bit out to the module that uses each bit
* sets a low state before switching the outputs to output mode. 
* removes the duplicate setup from net.c because UARTIntInit() already takes care of the UART pins
* fixes the real bug that kept my car awake, led_set uses digit to flash rather than the led number as an index into PORTC when digit == OVMS_LED_ON == -1 which means, in that case, it always sets RC3 which isn't an LED.