### PR TITLE
Nissan leaf remote climate control

### DIFF
--- a/vehicle/OVMS.X/net_msg.h
+++ b/vehicle/OVMS.X/net_msg.h
@@ -103,6 +103,8 @@ void net_msg_cmd_do(void);
 #define CMD_SendUSSD            41  // (USSD_CODE)
 #define CMD_SendRawAT           42  // (raw AT command)
 
+#define CMD_ClimateControl      43  // (ON or OFF)
+
 void net_msg_forward_sms(char* caller, char* SMS);
 void net_msg_reply_ussd(char *buf, unsigned char buflen);
 

--- a/vehicle/OVMS.X/net_msg.h
+++ b/vehicle/OVMS.X/net_msg.h
@@ -91,6 +91,8 @@ void net_msg_cmd_do(void);
 #define CMD_Reboot              5   // ()
 #define CMD_Alert               6   // ()
 
+#define CMD_StartCharge         11  // ()
+
 #define CMD_Lock                20  // (pin)
 #define CMD_UnLock              22  // (pin)
 #define CMD_ValetOn             21  // (pin)

--- a/vehicle/OVMS.X/vehicle_nissanleaf.c
+++ b/vehicle/OVMS.X/vehicle_nissanleaf.c
@@ -266,27 +266,31 @@ BOOL vehicle_nissanleaf_ticker1(void)
 
 void vehicle_nissanleaf_cc(BOOL enable_cc)
   {
-  if (sys_features[FEATURE_CANWRITE] > 0)
+  if (sys_features[FEATURE_CANWRITE] == 0)
     {
-    net_puts_rom("\r\n# Turning on/off CC\r\n"); // TODO remove debug
-    while (TXB0CONbits.TXREQ)
-      {
-      } // Loop until TX is done
-    TXB0CON = 0;
-    TXB0SIDL = (0x56e & 0x7) << 5;
-    TXB0SIDH = 0x56e >> 3;
-    if (enable_cc)
-      {
-      TXB0D0 = 0x4e;
-      }
-    else
-      {
-      TXB0D0 = 0x56;
-      }
-    TXB0DLC = 1; // data length
-    TXB0CON = 0b00001000; // mark for transmission
-    net_puts_rom("\r\n# Turned on/off CC\r\n"); // TODO remove debug
+    net_puts_rom("\r\n# CANRITE disabled, not doing remote CC\r\n"); // TODO remove debug
+    // we don't want to transmit when CAN write is disabled.
+    return;
     }
+  net_puts_rom("\r\n# Turning on/off CC\r\n"); // TODO remove debug
+  while (TXB0CONbits.TXREQ)
+    {
+    // Loop until TX is done
+    }
+  TXB0CON = 0;
+  TXB0SIDL = (0x56e & 0x7) << 5;
+  TXB0SIDH = 0x56e >> 3;
+  if (enable_cc)
+    {
+    TXB0D0 = 0x4e;
+    }
+  else
+    {
+    TXB0D0 = 0x56;
+    }
+  TXB0DLC = 1; // data length
+  TXB0CON = 0b00001000; // mark for transmission
+  net_puts_rom("\r\n# Turned on/off CC\r\n"); // TODO remove debug
   }
 
 ////////////////////////////////////////////////////////////////////////

--- a/vehicle/OVMS.X/vehicle_nissanleaf.c
+++ b/vehicle/OVMS.X/vehicle_nissanleaf.c
@@ -371,18 +371,28 @@ void vehicle_nissanleaf_remote_command(RemoteCommand command)
 
 BOOL vehicle_nissanleaf_fn_commandhandler(BOOL msgmode, int cmd, char *msg)
   {
-  // TODO climate control shouldn't be hooked to these commands
+  int button;
   switch (cmd)
     {
     case CMD_StartCharge:
       vehicle_nissanleaf_remote_command(START_CHARGING);
       break;
     case CMD_Homelink:
-      vehicle_nissanleaf_remote_command(ENABLE_CLIMATE_CONTROL);
-      break;
-    case CMD_Alert:
-      vehicle_nissanleaf_remote_command(DISABLE_CLIMATE_CONTROL);
-      break;
+      // TODO remove when the app supports CMD_EnableClimateControl et al
+      button = atoi(msg);
+      if (button == 0)
+        {
+        vehicle_nissanleaf_remote_command(ENABLE_CLIMATE_CONTROL);
+        }
+      else if (button == 1)
+        {
+        vehicle_nissanleaf_remote_command(DISABLE_CLIMATE_CONTROL);
+        }
+      else
+        {
+        // TODO should return invalid syntax
+        return FALSE;
+        }
     }
   // we return false even on success so the framework takes care of the response
   return FALSE;

--- a/vehicle/OVMS.X/vehicle_nissanleaf.c
+++ b/vehicle/OVMS.X/vehicle_nissanleaf.c
@@ -371,20 +371,36 @@ void vehicle_nissanleaf_remote_command(RemoteCommand command)
 
 BOOL vehicle_nissanleaf_fn_commandhandler(BOOL msgmode, int cmd, char *msg)
   {
-  int button;
+  // Temporary support via homelink command
+  // TODO remove when the app supports CMD_ClimateControl
+  if (cmd == CMD_Homelink)
+    {
+    int button = atoi(msg);
+    if (button == 0)
+      {
+      cmd = CMD_ClimateControl;
+      strcpypgm2ram(msg, "ON");
+      }
+    else if (button == 1)
+      {
+      cmd = CMD_ClimateControl;
+      strcpypgm2ram(msg, "OFF");
+      }
+    }
+  // end of temporary support
+
   switch (cmd)
     {
     case CMD_StartCharge:
       vehicle_nissanleaf_remote_command(START_CHARGING);
       break;
-    case CMD_Homelink:
-      // TODO remove when the app supports CMD_EnableClimateControl et al
-      button = atoi(msg);
-      if (button == 0)
+    case CMD_ClimateControl:
+      strupr(msg);
+      if (strcmppgm2ram(msg, "ON") == 0)
         {
         vehicle_nissanleaf_remote_command(ENABLE_CLIMATE_CONTROL);
         }
-      else if (button == 1)
+      else if (strcmppgm2ram(msg, "OFF") == 0)
         {
         vehicle_nissanleaf_remote_command(DISABLE_CLIMATE_CONTROL);
         }
@@ -393,6 +409,10 @@ BOOL vehicle_nissanleaf_fn_commandhandler(BOOL msgmode, int cmd, char *msg)
         // TODO should return invalid syntax
         return FALSE;
         }
+      break;
+    default:
+      // not one of our commands, return FALSE and the framework will handle it
+      return FALSE;
     }
   // we return false even on success so the framework takes care of the response
   return FALSE;

--- a/vehicle/OVMS.X/vehicle_nissanleaf.c
+++ b/vehicle/OVMS.X/vehicle_nissanleaf.c
@@ -325,11 +325,9 @@ void vehicle_nissanleaf_cc(BOOL enable_cc)
   unsigned char data;
   if (sys_features[FEATURE_CANWRITE] == 0)
     {
-    net_puts_rom("\r\n# CANRITE disabled, not doing remote CC\r\n"); // TODO remove debug
     // we don't want to transmit when CAN write is disabled.
     return;
     }
-  net_puts_rom("\r\n# Turning on/off CC\r\n"); // TODO remove debug
 
   // Use GPIO to wake up GEN 1 Leaf with EV SYSTEM ACTIVATION REQUEST
   output_gpo3(TRUE);
@@ -346,7 +344,6 @@ void vehicle_nissanleaf_cc(BOOL enable_cc)
   // send climate control command
   data = enable_cc ? 0x4e : 0x56;
   vehicle_nissanleaf_send_can_message(0x56e, 1, &data);
-  net_puts_rom("\r\n# Turned on/off CC\r\n"); // TODO remove debug
   }
 
 ////////////////////////////////////////////////////////////////////////

--- a/vehicle/OVMS.X/vehicle_nissanleaf.c
+++ b/vehicle/OVMS.X/vehicle_nissanleaf.c
@@ -247,6 +247,84 @@ BOOL vehicle_nissanleaf_ticker1(void)
   }
 
 ////////////////////////////////////////////////////////////////////////
+// vehicle_nissanleaf_cc_on()
+// Send Climate Control on message to VCU, normally sent by TCU, see
+// http://www.mynissanleaf.com/viewtopic.php?f=44&t=4131&hilit=open+CAN+discussion&start=416
+//
+// On Gen 1, turning on only works during charging, perhaps because the TCU has
+// a "wake up" logic line to the VCU in addition to the CAN bus which we need to
+// toggle as well as send this message.
+//
+// Tried without success to simulate wakeup by:
+// opening the door (difficult to send the message immediately after wakeup)
+// turning on the accessories
+// turning the whole car on
+//
+// CC *is* enabled if this function is called while the car is charging
+//
+
+void vehicle_nissanleaf_cc_on()
+  {
+  if (sys_features[FEATURE_CANWRITE] > 0)
+    {
+    net_puts_rom("\r\n# Turning on CC\r\n"); // TODO remove debug
+    while (TXB0CONbits.TXREQ)
+      {
+      } // Loop until TX is done
+    TXB0CON = 0;
+    TXB0SIDL = (0x56e & 0x7) << 5;
+    TXB0SIDH = 0x56e >> 3;
+    TXB0D0 = 0x4E;
+    TXB0DLC = 1; // data length
+    TXB0CON = 0b00001000; // mark for transmission
+    net_puts_rom("\r\n# Turned on CC\r\n"); // TODO remove debug
+    }
+  }
+
+////////////////////////////////////////////////////////////////////////
+// vehicle_nissanleaf_cc_off()
+// Send Climate Control off message to VCU, normally sent by TCU, see
+// vehicle_nissanleaf_cc_on() for details.
+
+void vehicle_nissanleaf_cc_off()
+  {
+  if (sys_features[FEATURE_CANWRITE] > 0)
+    {
+    net_puts_rom("\r\n# Turning off CC\r\n"); // TODO remove debug
+    while (TXB0CONbits.TXREQ)
+      {
+      } // Loop until TX is done
+    TXB0CON = 0;
+    TXB0SIDL = (0x56e & 0x7) << 5;
+    TXB0SIDH = 0x56e >> 3;
+    TXB0D0 = 0x56;
+    TXB0DLC = 1; // data length
+    TXB0CON = 0b00001000; // mark for transmission
+    net_puts_rom("\r\n# Turned off CC\r\n"); // TODO remove debug
+    }
+  }
+
+////////////////////////////////////////////////////////////////////////
+// vehicle_nissanleaf_fn_commandhandler()
+// Remote Command Handler, decodes command and delegates actual work elsewhere
+
+BOOL vehicle_nissanleaf_fn_commandhandler(BOOL msgmode, int cmd, char *msg)
+  {
+  // TODO climate control shouldn't be hooked to these commands
+  switch (cmd)
+    {
+    case CMD_Homelink:
+      vehicle_nissanleaf_cc_on();
+      break;
+    case CMD_Alert:
+      vehicle_nissanleaf_cc_off();
+      break;
+    }
+  // we return false even on success so the framework takes care of the response
+  return FALSE;
+  }
+
+////////////////////////////////////////////////////////////////////////
 // vehicle_nissanleaf_initialise()
 // This function is an entry point from the main() program loop, and
 // gives the CAN framework an opportunity to initialise itself.
@@ -327,6 +405,7 @@ BOOL vehicle_nissanleaf_initialise(void)
   vehicle_fn_poll0 = &vehicle_nissanleaf_poll0;
   vehicle_fn_poll1 = &vehicle_nissanleaf_poll1;
   vehicle_fn_ticker1 = &vehicle_nissanleaf_ticker1;
+  vehicle_fn_commandhandler = &vehicle_nissanleaf_fn_commandhandler;
 
   // TODO this causes a relay to click every 20 seconds or so while charging
   // TODO and on my gen 1 car at least, does not get the VIN number or speed

--- a/vehicle/OVMS.X/vehicle_nissanleaf.c
+++ b/vehicle/OVMS.X/vehicle_nissanleaf.c
@@ -95,13 +95,17 @@ rom vehicle_pid_t vehicle_nissanleaf_polls[]
 
 ////////////////////////////////////////////////////////////////////////
 // vehicle_nissanleaf_send_can_message()
-// Send the specified can frame, does nothing if FEATURE_CANWRITE is not set
+// Send the specified can frame. Does nothing if FEATURE_CANWRITE is not set,
+// does nothing if length > 8.
 //
 // TODO move to util?
 
 void vehicle_nissanleaf_send_can_message(short id, unsigned char length, unsigned char *data)
   {
-  if (sys_features[FEATURE_CANWRITE] == 0)
+  volatile far unsigned char *txb0 = &TXB0D0;
+  UINT8 i;
+
+  if (sys_features[FEATURE_CANWRITE] == 0 || length > 8)
     {
     return;
     }
@@ -111,39 +115,9 @@ void vehicle_nissanleaf_send_can_message(short id, unsigned char length, unsigne
   TXB0CON = 0;
   TXB0SIDL = (id & 0x7) << 5;
   TXB0SIDH = id >> 3;
-  // TODO it would be nicer to copy in a loop here, can we assume the CAN tx
-  // buffer is sequential? Would the code be smaller or faster?
-  if (length > 0)
+  for (i = 0; i < length; i++)
     {
-    TXB0D0 = data[0];
-    }
-  if (length > 1)
-    {
-    TXB0D1 = data[1];
-    }
-  if (length > 2)
-    {
-    TXB0D2 = data[2];
-    }
-  if (length > 3)
-    {
-    TXB0D3 = data[3];
-    }
-  if (length > 4)
-    {
-    TXB0D4 = data[4];
-    }
-  if (length > 5)
-    {
-    TXB0D5 = data[5];
-    }
-  if (length > 6)
-    {
-    TXB0D6 = data[6];
-    }
-  if (length > 7)
-    {
-    TXB0D7 = data[7];
+    txb0[i] = data[i];
     }
   TXB0DLC = length; // data length
   TXB0CON = 0b00001000; // mark for transmission


### PR DESCRIPTION
CMD_StartCharge is a define for an already existing command.

Works on Gen 2 with no hardware modifications and on Gen 1 with a circuit on gpo3 to wake up the car.

Diff shows a removal of #pragma tmpdata high_isr_tmpdata but actually it was moved above the comment and a new function.