### PR TITLE
Nissan leaf climate control off

### DIFF
--- a/vehicle/OVMS.X/vehicle_nissanleaf.c
+++ b/vehicle/OVMS.X/vehicle_nissanleaf.c
@@ -595,6 +595,11 @@ BOOL vehicle_nissanleaf_ticker1(void)
     // we're not on grid power so switch off early
     nl_cc_off_ticker = 1;
     }
+  if (nl_cc_off_ticker > 1 && car_doors1bits.CarON)
+    {
+    // car has turned on during climate control, switch climate control off
+    nl_cc_off_ticker = 1;
+    }
   if (nl_cc_off_ticker == 1)
     {
     vehicle_nissanleaf_remote_command(DISABLE_CLIMATE_CONTROL);

--- a/vehicle/OVMS.X/vehicle_nissanleaf.c
+++ b/vehicle/OVMS.X/vehicle_nissanleaf.c
@@ -33,7 +33,7 @@
 #include "inputs.h"
 
 // Nissan Leaf module version:
-rom char nissanleaf_version[] = "1.3";
+rom char nissanleaf_version[] = "1.4";
 
 // Nissan Leaf capabilities:
 // - CMD_StartCharge (11)


### PR DESCRIPTION
Send the climate control turn off command after 15 minutes of remote climate control on battery power or 30 minutes if connected to the grid. Also sends the climate control off command If the car is switched on during remote climate control.

This is required as at least some Gen 2 cars will run the climate control indefinitely, resuming even after driving the car.